### PR TITLE
Fix syntax error in blog admin page

### DIFF
--- a/admin/blog.php
+++ b/admin/blog.php
@@ -31,19 +31,7 @@ if(isset($_POST['btn-save']))
         }
     }
 }
-  $productauth_serial = $foo[$count][0];
-                mysqli_stmt_bind_param($stmt, 's', $productauth_serial);
-                mysqli_stmt_execute($stmt);
-            }
-            mysqli_stmt_close($stmt);
-            $msg= '<p style="background: green; color: #fff; padding: 10px; text-align: center; margin-bottom: 20px; color: white;">Code Added successfully</p>';
-        }  else{
-            $msg='<p style="background: #c75c5c; color: #fff; padding: 10px; text-align: center; margin-bottom: 20px; color: white;">Operation failed </p>';
-        }
-    }
-}
-
-	?>
+?>
 
 <!DOCTYPE html>
 <!--[if IE 8]>			<html class="ie ie8"> <![endif]-->


### PR DESCRIPTION
## Summary
- remove leftover code in `admin/blog.php` that caused unmatched braces and 500 error

## Testing
- `php -l admin/blog.php`
- `php -l admin/blogedit.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad842c876c83238927c2d16c118284