### PR TITLE
Fix CSV upload path in blog admin

### DIFF
--- a/admin/blog.php
+++ b/admin/blog.php
@@ -37,7 +37,7 @@ if(isset($_POST['btn-save']))
 // handle CSV upload
 if (isset($_POST['import']) && isset($_FILES['excel_file'])) {
     if (is_uploaded_file($_FILES['excel_file']['tmp_name'])) {
-        require_once 'SimpleExcel/SimpleExcel.php';
+        require_once __DIR__ . '/SimpleExcel/SimpleExcel.php';
         $excel = new SimpleExcel('csv');
         $excel->parser->loadFile($_FILES['excel_file']['tmp_name']);
         $rows = $excel->parser->getField();


### PR DESCRIPTION
## Summary
- Use an absolute path when loading the SimpleExcel library in `admin/blog.php` to prevent include errors during CSV uploads.

## Testing
- `php -l admin/blog.php`
- `php -l admin/SimpleExcel/Parser/CSVParser.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad89f5f47c832398b487a8297c78e3