### PR TITLE
Fix DB config syntax for CSV upload

### DIFF
--- a/admin/config.php
+++ b/admin/config.php
@@ -8,6 +8,6 @@ $dbhost = "localhost";
 $dbuser = "tea";
 $dbpass = "computer@123";
 $dbname = "bvm";*/
-$conn = mysqli_connect($dbhost,$dbuser,$dbpass,$dbname) or die( print_r(mysqli_error($conn)))
+$conn = mysqli_connect($dbhost,$dbuser,$dbpass,$dbname) or die( print_r(mysqli_error($conn)));
 
 ?>


### PR DESCRIPTION
## Summary
- add missing semicolon in `admin/config.php` to fix database connection

## Testing
- `php -l admin/config.php`
- `php -l admin/blog.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad8d80e7b4832396157b3a44942438